### PR TITLE
Various fixes / Victory and Super Victory Endings

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -76,8 +76,8 @@ android {
         applicationId = "org.broguece.game"
         minSdk = 24
         targetSdk = 35
-        versionCode = 1150121
-        versionName = "1.15.1.21"
+        versionCode = 1150122
+        versionName = "1.15.1.22"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a", "x86_64")

--- a/android/app/src/main/java/org/broguece/game/BrogueActivity.java
+++ b/android/app/src/main/java/org/broguece/game/BrogueActivity.java
@@ -24,6 +24,7 @@ public class BrogueActivity extends SDLActivity {
     FrameLayout gameOverlay;
     FrameLayout inventoryOverlay;
     private View loadingOverlay;
+    private View transitionVeil;
 
     // Feature classes. Package-private so other features can reference them
     // directly (e.g. StartMenu → extrasModal.show()).
@@ -41,6 +42,7 @@ public class BrogueActivity extends SDLActivity {
     final NewGameSeedModal newGameSeedModal = new NewGameSeedModal(this);
     final ReplayRecentSeedModal replayRecentSeedModal = new ReplayRecentSeedModal(this);
     final DeathModal deathModal = new DeathModal(this);
+    final VictoryModal victoryModal = new VictoryModal(this);
     private SettingsPanel settingsPanel;
     private ExitPanel exitPanel;
     private ActionsToolbar actionsToolbar;
@@ -179,8 +181,9 @@ public class BrogueActivity extends SDLActivity {
         StatsStore.get(this).recordAmuletPickedUp();
     }
 
-    public void onPlayerDied(final String killedBy, final int depth, final int turns) {
-        StatsStore.get(this).recordPlayerDied(killedBy, depth, turns);
+    public void onPlayerDied(final String killedBy, final int depth, final int deepest,
+            final int turns) {
+        StatsStore.get(this).recordPlayerDied(killedBy, depth, deepest, turns);
         reportGameEnd("died", depth, turns);
     }
 
@@ -191,17 +194,24 @@ public class BrogueActivity extends SDLActivity {
     public native void nativeDeathFadeDone();
     public native void nativeDeathScreenDismissed();
 
+    public void showVictorySequence(final String json) {
+        victoryModal.showSequence(json);
+    }
+
+    public native void nativeVictorySequenceDismissed();
+
     public void onDeathFlamesReady() {
         deathModal.onFlamesReady();
     }
 
-    public void onPlayerWon(final boolean superVictory, final int depth, final int turns) {
-        StatsStore.get(this).recordPlayerWon(superVictory, depth, turns);
+    public void onPlayerWon(final boolean superVictory, final int depth, final int deepest,
+            final int turns) {
+        StatsStore.get(this).recordPlayerWon(superVictory, deepest, turns);
         reportGameEnd("won", depth, turns);
     }
 
-    public void onPlayerQuit(final int depth, final int turns) {
-        StatsStore.get(this).recordPlayerQuit();
+    public void onPlayerQuit(final int depth, final int deepest, final int turns) {
+        StatsStore.get(this).recordPlayerQuit(deepest);
         reportGameEnd("quit", depth, turns);
     }
 
@@ -226,6 +236,7 @@ public class BrogueActivity extends SDLActivity {
         android.util.Log.d("BrogueModal", "setOverlayVisible(" + visible + ")");
         runOnUiThread(() -> {
             if (visible) {
+                clearTransitionVeil();
                 // A game is on-screen — drop title-menu modals so they can't
                 // resurface after the engine returns to the title later.
                 modalStack.clear();
@@ -236,6 +247,7 @@ public class BrogueActivity extends SDLActivity {
                 // immediately instead of making the user tap through flames.
                 modalStack.restore();
                 deathModal.fadeOutOverlay();
+                victoryModal.fadeOutOverlay();
             }
             gameOverlay.setVisibility(visible ? View.VISIBLE : View.GONE);
         });
@@ -258,6 +270,38 @@ public class BrogueActivity extends SDLActivity {
         }
         ((TextView) loadingOverlay).setText(text);
         loadingOverlay.setVisibility(View.VISIBLE);
+        loadingOverlay.bringToFront(); // above any transition veil already up
+    }
+
+    /** Fades the screen out before a menu choice hands control to the engine,
+     *  which otherwise cuts straight from the title to loading. Cleared by
+     *  setOverlayVisible once the game is on screen. */
+    void fadeToBlackThen(final Runnable action) {
+        runOnUiThread(() -> {
+            if (transitionVeil == null) {
+                transitionVeil = new View(this);
+                transitionVeil.setBackgroundColor(Color.BLACK);
+                transitionVeil.setClickable(true);
+                addContentView(transitionVeil, new FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT));
+            }
+            transitionVeil.bringToFront();
+            transitionVeil.setAlpha(0f);
+            transitionVeil.animate().alpha(1f).setDuration(400)
+                .withEndAction(action).start();
+        });
+    }
+
+    private void clearTransitionVeil() {
+        if (transitionVeil == null) return;
+        final View veil = transitionVeil;
+        transitionVeil = null;
+        veil.animate().alpha(0f).setDuration(400).withEndAction(() -> {
+            if (veil.getParent() != null) {
+                ((android.view.ViewGroup) veil.getParent()).removeView(veil);
+            }
+        }).start();
     }
 
     public void setLoadingVisible(final boolean visible) {
@@ -266,6 +310,15 @@ public class BrogueActivity extends SDLActivity {
                 showStatusOverlay("LOADING");
             } else if (loadingOverlay != null) {
                 loadingOverlay.setVisibility(View.GONE);
+            }
+        });
+    }
+
+    /** Called from C while replaying a save file; percent advances in ~1% steps. */
+    public void setLoadingProgress(final int percent) {
+        runOnUiThread(() -> {
+            if (loadingOverlay != null && loadingOverlay.getVisibility() == View.VISIBLE) {
+                ((TextView) loadingOverlay).setText("LOADING " + percent + "%");
             }
         });
     }

--- a/android/app/src/main/java/org/broguece/game/InventoryOverlay.java
+++ b/android/app/src/main/java/org/broguece/game/InventoryOverlay.java
@@ -93,8 +93,10 @@ final class InventoryOverlay {
                 headerBar.setGravity(Gravity.CENTER_VERTICAL);
 
                 TextView header = new TextView(activity);
-                // 26 = a–z inventory letter cap (MAX_PACK_ITEMS in the engine).
-                String inventoryHeader = "INVENTORY ( " + items.length() + " / 26 )";
+                // The engine counts stacks per-quantity against MAX_PACK_ITEMS,
+                // so packCount can exceed the number of rows shown.
+                int packCount = root.optInt("packCount", items.length());
+                String inventoryHeader = "INVENTORY ( " + packCount + " / 26 )";
                 header.setText(selectMode && !prompt.isEmpty() ? prompt
                     : selectMode ? "SELECT ITEM" : inventoryHeader);
                 header.setTextColor(selectMode ? Palette.PALE_BLUE : Palette.FLAME_EMBER);

--- a/android/app/src/main/java/org/broguece/game/Palette.java
+++ b/android/app/src/main/java/org/broguece/game/Palette.java
@@ -12,6 +12,9 @@ final class Palette {
     static final int FLAME_DIM      = Color.argb(255, 100, 55, 20);  // subdued flame
     static final int PALE_BLUE      = Color.argb(255, 140, 150, 190);// flameTitleColor text
     static final int GHOST_WHITE    = Color.argb(255, 210, 205, 220);
+    static final int GOLD_TEXT      = Color.argb(255, 230, 200, 90);  // treasure values
+    static final int SUNLIT_TEXT    = Color.argb(255, 90, 60, 20);    // dark sepia on the white victory veil
+    static final int SUNLIT_HINT    = Color.argb(150, 90, 60, 20);
     static final int VOID_BLACK     = Color.argb(240, 8, 6, 16);
     static final int SUBMENU_BG     = Color.argb(235, 12, 10, 25);
     static final int RIPPLE_GLOW    = Color.argb(80, 180, 120, 50);

--- a/android/app/src/main/java/org/broguece/game/PlayerStats.java
+++ b/android/app/src/main/java/org/broguece/game/PlayerStats.java
@@ -164,7 +164,9 @@ final class PlayerStats {
             copyDepths(deathsPerDepth));
     }
 
-    PlayerStats withPlayerDied(String killedBy, int depth, int turns) {
+    /** depth is where the player died, which the histogram wants; deepest is
+     *  how far down the run reached, which can be further up the dungeon. */
+    PlayerStats withPlayerDied(String killedBy, int depth, int deepest, int turns) {
         int[] nextDepths = copyDepths(deathsPerDepth);
         if (depth >= 1 && depth <= MAX_DEPTH) {
             nextDepths[depth]++;
@@ -173,7 +175,7 @@ final class PlayerStats {
             gamesPlayed,
             wins, masteryWins,
             deaths + 1,
-            Math.max(deepestDepth, depth),
+            Math.max(deepestDepth, deepest),
             Math.max(longestRunTurns, turns),
             fastestWinTurns,
             amuletPickups,
@@ -185,7 +187,7 @@ final class PlayerStats {
             nextDepths);
     }
 
-    PlayerStats withPlayerWon(boolean superVictory, int depth, int turns) {
+    PlayerStats withPlayerWon(boolean superVictory, int deepest, int turns) {
         int nextFastest = (fastestWinTurns == 0 || turns < fastestWinTurns)
             ? turns : fastestWinTurns;
         return new PlayerStats(
@@ -193,7 +195,7 @@ final class PlayerStats {
             wins + 1,
             masteryWins + (superVictory ? 1 : 0),
             deaths,
-            Math.max(deepestDepth, depth),
+            Math.max(deepestDepth, deepest),
             Math.max(longestRunTurns, turns),
             nextFastest,
             amuletPickups,
@@ -244,11 +246,11 @@ final class PlayerStats {
             copyDepths(deathsPerDepth));
     }
 
-    PlayerStats withPlayerQuit() {
+    PlayerStats withPlayerQuit(int deepest) {
         return new PlayerStats(
             gamesPlayed,
             wins, masteryWins, deaths,
-            deepestDepth, longestRunTurns, fastestWinTurns, amuletPickups,
+            Math.max(deepestDepth, deepest), longestRunTurns, fastestWinTurns, amuletPickups,
             new ArrayList<>(kills),
             new ArrayList<>(deathCauses),
             new ArrayList<>(alliesFreed),

--- a/android/app/src/main/java/org/broguece/game/SeedDetailsModal.java
+++ b/android/app/src/main/java/org/broguece/game/SeedDetailsModal.java
@@ -240,12 +240,14 @@ class SeedDetailsModal {
 
     private void launchRun() {
         if (seed <= 0) return;   // weekly modal: /weekly hasn't landed yet
-        activity.modalStack.clear();
-        activity.startMenu.dismiss();
-        // Starting a new run overwrites the save slot; drop the existing
-        // save first so /game/start telemetry and the fresh run agree.
-        activity.nativeDeleteSaveFile();
-        activity.nativeStartMenuResultWithSeed(StartMenu.CHOICE_PLAY_SEED, seed);
+        activity.fadeToBlackThen(() -> {
+            activity.modalStack.clear();
+            activity.startMenu.dismiss();
+            // Starting a new run overwrites the save slot; drop the existing
+            // save first so /game/start telemetry and the fresh run agree.
+            activity.nativeDeleteSaveFile();
+            activity.nativeStartMenuResultWithSeed(StartMenu.CHOICE_PLAY_SEED, seed);
+        });
     }
 
     private TextView addStatTile(LinearLayout parent, String value, String label) {

--- a/android/app/src/main/java/org/broguece/game/StartMenu.java
+++ b/android/app/src/main/java/org/broguece/game/StartMenu.java
@@ -126,10 +126,12 @@ final class StartMenu {
             // event to /game/resume (no plays bump) instead of /game/start.
             boolean canResume = hasSave && saveCompatible;
             addButton(panel, "Resume Game", canResume, v -> {
-                activity.modalStack.clear();
-                dismiss();
                 activity.nextGameIsResume = true;
-                activity.nativeStartMenuResult(CHOICE_RESUME);
+                activity.fadeToBlackThen(() -> {
+                    activity.modalStack.clear();
+                    dismiss();
+                    activity.nativeStartMenuResult(CHOICE_RESUME);
+                });
             });
 
             addButton(panel, "Extras", true,

--- a/android/app/src/main/java/org/broguece/game/StatsStore.java
+++ b/android/app/src/main/java/org/broguece/game/StatsStore.java
@@ -138,13 +138,14 @@ final class StatsStore {
         post("recordMonsterKilled", s -> s.withMonsterKilled(name));
     }
 
-    void recordPlayerDied(final String killedBy, final int depth, final int turns) {
+    void recordPlayerDied(final String killedBy, final int depth, final int deepest,
+            final int turns) {
         final String safeKilledBy = killedBy == null ? "" : killedBy;
-        post("recordPlayerDied", s -> s.withPlayerDied(safeKilledBy, depth, turns));
+        post("recordPlayerDied", s -> s.withPlayerDied(safeKilledBy, depth, deepest, turns));
     }
 
-    void recordPlayerWon(final boolean superVictory, final int depth, final int turns) {
-        post("recordPlayerWon", s -> s.withPlayerWon(superVictory, depth, turns));
+    void recordPlayerWon(final boolean superVictory, final int deepest, final int turns) {
+        post("recordPlayerWon", s -> s.withPlayerWon(superVictory, deepest, turns));
     }
 
     void recordAmuletPickedUp() {
@@ -156,8 +157,8 @@ final class StatsStore {
         post("recordSeedPlayed", s -> s.withSeedPlayed(seed));
     }
 
-    void recordPlayerQuit() {
-        post("recordPlayerQuit", PlayerStats::withPlayerQuit);
+    void recordPlayerQuit(final int deepest) {
+        post("recordPlayerQuit", s -> s.withPlayerQuit(deepest));
     }
 
     private PlayerStats loadFromDisk() {

--- a/android/app/src/main/java/org/broguece/game/VictoryModal.java
+++ b/android/app/src/main/java/org/broguece/game/VictoryModal.java
@@ -1,0 +1,440 @@
+package org.broguece.game;
+
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.GradientDrawable;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.animation.DecelerateInterpolator;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/** The win sequence, shown once the engine's whiteout has filled the screen:
+ *  two sunlit text pages over a white backdrop, then a fade to black and the
+ *  treasure, achievement and final-score panels. Every page advances on tap;
+ *  the last one leaves the screen black for the title to fade in under. */
+final class VictoryModal {
+
+    private final BrogueActivity activity;
+    private FrameLayout root;
+    private View whiteVeil;
+    private View blackVeil;
+    private View currentPage;
+    private JSONObject data;
+    private int pageIndex;
+
+    VictoryModal(BrogueActivity activity) {
+        this.activity = activity;
+    }
+
+    /** Called from C after the flood completes; blocks the engine thread
+     *  until the last page is tapped. */
+    void showSequence(final String json) {
+        activity.runOnUiThread(() -> {
+            ensureRoot();
+            try {
+                data = new JSONObject(json);
+            } catch (Exception e) {
+                data = new JSONObject();
+            }
+            pageIndex = 0;
+            showPage();
+        });
+    }
+
+    /** Engine returned to the title screen — reveal it under the overlay. */
+    void fadeOutOverlay() {
+        if (root == null) {
+            return;
+        }
+        if (currentPage != null) {
+            root.removeView(currentPage);
+            currentPage = null;
+        }
+        // The restored start menu is added above this overlay, so raise the
+        // black again or the menu pops in over the fade instead of under it.
+        root.bringToFront();
+        // Fading the root group can composite per-child, flashing the white
+        // veil through the black; drop it and fade the black leaf alone.
+        if (whiteVeil != null) {
+            root.removeView(whiteVeil);
+            whiteVeil = null;
+        }
+        // Let the title's flame loop put up a frame before revealing it.
+        blackVeil.animate()
+            .alpha(0f)
+            .setStartDelay(300)
+            .setDuration(900)
+            .setInterpolator(new DecelerateInterpolator(1.5f))
+            .withEndAction(this::removeOverlay)
+            .start();
+    }
+
+    void removeOverlay() {
+        if (root != null && root.getParent() != null) {
+            ((android.view.ViewGroup) root.getParent()).removeView(root);
+        }
+        root = null;
+        whiteVeil = null;
+        blackVeil = null;
+        currentPage = null;
+    }
+
+    private void ensureRoot() {
+        if (root != null) return;
+
+        root = new FrameLayout(activity);
+        // Swallow every touch that no page consumes — nothing may reach the
+        // game surface during the sequence or the fades.
+        root.setClickable(true);
+
+        whiteVeil = new View(activity);
+        whiteVeil.setBackgroundColor(Color.WHITE);
+        root.addView(whiteVeil, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT));
+
+        blackVeil = new View(activity);
+        blackVeil.setBackgroundColor(Color.BLACK);
+        blackVeil.setAlpha(0f);
+        root.addView(blackVeil, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT));
+
+        activity.addContentView(root, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT));
+    }
+
+    /** Detach a page's tap handling so it can't fire again mid-fade. */
+    private static void deafen(View page) {
+        if (page == null) return;
+        page.setOnClickListener(null);
+        page.setClickable(false);
+    }
+
+    private void advance() {
+        pageIndex++;
+
+        if (pageIndex == 2) {
+            // Sunlit pages done — fade to black, then the dark panels.
+            final View old = currentPage;
+            currentPage = null;
+            deafen(old);
+            if (old != null) {
+                old.animate().alpha(0f).setDuration(250)
+                    .withEndAction(() -> { if (root != null) root.removeView(old); })
+                    .start();
+            }
+            blackVeil.animate()
+                .alpha(1f)
+                .setDuration(800)
+                .setInterpolator(new DecelerateInterpolator(1.5f))
+                .withEndAction(this::showPage)
+                .start();
+            return;
+        }
+
+        if (pageIndex == 5) {
+            // Let the last panel fade away completely, then cut the stinger in.
+            final View old = currentPage;
+            currentPage = null;
+            deafen(old);
+            if (old != null) {
+                old.animate().alpha(0f).setDuration(800)
+                    .withEndAction(() -> {
+                        if (root != null) root.removeView(old);
+                        showPage();
+                    })
+                    .start();
+            } else {
+                showPage();
+            }
+            return;
+        }
+
+        if (pageIndex > 5) {
+            // Fade to solid black before releasing the engine, so teardown
+            // and title startup happen unseen; fadeOutOverlay reveals them.
+            final View old = currentPage;
+            currentPage = null;
+            deafen(old);
+            if (old != null) {
+                old.animate().alpha(0f).setDuration(1200)
+                    .withEndAction(() -> {
+                        if (root != null) root.removeView(old);
+                        activity.nativeVictorySequenceDismissed();
+                    })
+                    .start();
+            } else {
+                activity.nativeVictorySequenceDismissed();
+            }
+            return;
+        }
+
+        showPage();
+    }
+
+    private void showPage() {
+        if (root == null) return;
+
+        if (currentPage != null) {
+            final View old = currentPage;
+            deafen(old);
+            old.animate().alpha(0f).setDuration(200)
+                .withEndAction(() -> { if (root != null) root.removeView(old); })
+                .start();
+        }
+
+        View page;
+        switch (pageIndex) {
+            case 0:  page = buildSunlitPage(data.optString("headline", "")); break;
+            case 1:  page = buildSunlitPage(data.optString("congrats", "")); break;
+            case 5:  page = buildStingerPage(data.optString("stinger", "")); break;
+            default: page = buildPanelPage(); break;
+        }
+
+        root.addView(page, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT));
+        currentPage = page;
+    }
+
+    /** Raw centered sepia text on the white veil — no panel chrome. */
+    private View buildSunlitPage(String text) {
+        final FrameLayout page = new FrameLayout(activity);
+        page.setOnClickListener(v -> { if (page == currentPage) advance(); });
+
+        TextView tv = new TextView(activity);
+        tv.setText(text);
+        tv.setTextColor(Palette.SUNLIT_TEXT);
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16);
+        tv.setTypeface(Typeface.MONOSPACE);
+        tv.setGravity(Gravity.CENTER);
+        tv.setLineSpacing(0, 1.3f);
+        int pad = activity.dpToPx(40);
+        tv.setPadding(pad, pad, pad, pad);
+        page.addView(tv, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.CENTER));
+
+        TextView hint = new TextView(activity);
+        hint.setText("tap to continue");
+        hint.setTextColor(Palette.SUNLIT_HINT);
+        hint.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
+        hint.setTypeface(Typeface.MONOSPACE, Typeface.ITALIC);
+        FrameLayout.LayoutParams hintParams = new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL);
+        hintParams.setMargins(0, 0, 0, activity.dpToPx(28));
+        page.addView(hint, hintParams);
+
+        page.setAlpha(0f);
+        page.animate().alpha(1f).setDuration(450).start();
+        return page;
+    }
+
+    /** Closing line on the black, cut in rather than faded so it lands. */
+    private View buildStingerPage(String text) {
+        final FrameLayout page = new FrameLayout(activity);
+        page.setOnClickListener(v -> { if (page == currentPage) advance(); });
+
+        TextView tv = new TextView(activity);
+        tv.setText(text);
+        tv.setTextColor(Palette.PALE_BLUE);
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        tv.setTypeface(Typeface.MONOSPACE, Typeface.ITALIC);
+        tv.setGravity(Gravity.CENTER);
+        tv.setLineSpacing(0, 1.3f);
+        int pad = activity.dpToPx(40);
+        tv.setPadding(pad, pad, pad, pad);
+        page.addView(tv, new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.CENTER));
+        return page;
+    }
+
+    /** Dark Brogue-styled panel pages: 2 = treasures, 3 = achievements,
+     *  4 = final score. */
+    private View buildPanelPage() {
+        LinearLayout panel = new LinearLayout(activity);
+        panel.setOrientation(LinearLayout.VERTICAL);
+        int pad = activity.dpToPx(16);
+        panel.setPadding(pad, pad, pad, pad);
+
+        GradientDrawable panelBg = new GradientDrawable();
+        panelBg.setShape(GradientDrawable.RECTANGLE);
+        panelBg.setCornerRadius(activity.dpToPx(6));
+        panelBg.setColor(Palette.INVENTORY_BG);
+        panelBg.setStroke(1, Palette.BORDER_ACTIVE);
+        panel.setBackground(panelBg);
+        panel.setElevation(activity.dpToPx(12));
+
+        if (pageIndex == 2) {
+            addHeader(panel, "TREASURES");
+            addLine(panel, data.optString("epilogue", ""), Palette.GHOST_WHITE, 12, 0);
+            addTreasureRows(panel);
+        } else if (pageIndex == 3) {
+            addHeader(panel, "ACHIEVEMENTS");
+            JSONArray feats = data.optJSONArray("achievements");
+            if (feats == null || feats.length() == 0) {
+                addLine(panel, "None this run.", Palette.PALE_BLUE, 12, 0);
+            } else {
+                for (int i = 0; i < feats.length(); i++) {
+                    addLine(panel, feats.optString(i, ""), Palette.GOOD_MAGIC, 12, i == 0 ? 0 : 4);
+                }
+            }
+        } else {
+            addHeader(panel, "FINAL SCORE");
+            addLine(panel, String.valueOf(data.optLong("score", 0)), Palette.GOLD_TEXT, 18, 0);
+            addLine(panel, data.optLong("turns", 0) + " turns", Palette.PALE_BLUE, 12, 8);
+        }
+
+        TextView hint = new TextView(activity);
+        hint.setText(pageIndex == 4 ? "tap to finish" : "tap to continue");
+        hint.setTextColor(Palette.PALE_BLUE);
+        hint.setTextSize(TypedValue.COMPLEX_UNIT_SP, 10);
+        hint.setTypeface(Typeface.MONOSPACE, Typeface.ITALIC);
+        hint.setGravity(Gravity.CENTER);
+        hint.setPadding(0, activity.dpToPx(14), 0, 0);
+        panel.addView(hint);
+
+        ScrollView scroll = new ScrollView(activity);
+        scroll.setOverScrollMode(View.OVER_SCROLL_NEVER);
+        scroll.addView(panel);
+
+        final FrameLayout page = new FrameLayout(activity);
+        page.setOnClickListener(v -> { if (page == currentPage) advance(); });
+
+        // A tap on the panel advances, a drag still scrolls. ScrollView
+        // swallows click listeners, so detect the tap with a slop check.
+        final int slop = android.view.ViewConfiguration.get(activity).getScaledTouchSlop();
+        scroll.setOnTouchListener(new View.OnTouchListener() {
+            private float downX, downY;
+            private boolean tapping;
+            @Override public boolean onTouch(View v, android.view.MotionEvent e) {
+                switch (e.getActionMasked()) {
+                    case android.view.MotionEvent.ACTION_DOWN:
+                        downX = e.getRawX(); downY = e.getRawY();
+                        tapping = true;
+                        break;
+                    case android.view.MotionEvent.ACTION_MOVE:
+                        if (Math.abs(e.getRawX() - downX) > slop
+                                || Math.abs(e.getRawY() - downY) > slop) tapping = false;
+                        break;
+                    case android.view.MotionEvent.ACTION_UP:
+                        if (tapping && page == currentPage) advance();
+                        break;
+                }
+                return false;
+            }
+        });
+
+        int panelWidth = Math.min(activity.dpToPx(380),
+            (int)(activity.getResources().getDisplayMetrics().widthPixels * 0.85f));
+        // The padding caps the panel's height: a WRAP_CONTENT child is
+        // measured against the space left over, so a tall list scrolls.
+        int inset = activity.dpToPx(24);
+        page.setPadding(0, inset, 0, inset);
+        page.addView(scroll, new FrameLayout.LayoutParams(
+            panelWidth, FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.CENTER));
+
+        ModalChrome.animateIn(panel);
+        return page;
+    }
+
+    private void addTreasureRows(LinearLayout panel) {
+        JSONArray rows = data.optJSONArray("treasure");
+        if (rows == null) return;
+        for (int i = 0; i < rows.length(); i++) {
+            JSONObject row = rows.optJSONObject(i);
+            if (row == null) continue;
+
+            LinearLayout line = new LinearLayout(activity);
+            line.setOrientation(LinearLayout.HORIZONTAL);
+
+            TextView name = new TextView(activity);
+            name.setText(row.optString("name", ""));
+            name.setTextColor(Palette.GHOST_WHITE);
+            name.setTextSize(TypedValue.COMPLEX_UNIT_SP, 11);
+            name.setTypeface(Typeface.MONOSPACE);
+            line.addView(name, new LinearLayout.LayoutParams(
+                0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+
+            long value = row.optLong("value", 0);
+            if (value > 0) {
+                TextView val = new TextView(activity);
+                val.setText(String.valueOf(value));
+                val.setTextColor(Palette.GOLD_TEXT);
+                val.setTextSize(TypedValue.COMPLEX_UNIT_SP, 11);
+                val.setTypeface(Typeface.MONOSPACE);
+                val.setPadding(activity.dpToPx(12), 0, 0, 0);
+                line.addView(val);
+            }
+
+            LinearLayout.LayoutParams p = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT);
+            p.setMargins(0, activity.dpToPx(i == 0 ? 12 : 3), 0, 0);
+            panel.addView(line, p);
+        }
+
+        panel.addView(ModalChrome.makeEmberSeparator(activity),
+                      ModalChrome.emberSeparatorParams(activity, 8, 8, 12, 8));
+
+        LinearLayout totalLine = new LinearLayout(activity);
+        totalLine.setOrientation(LinearLayout.HORIZONTAL);
+        TextView totalLabel = new TextView(activity);
+        totalLabel.setText("TOTAL:");
+        totalLabel.setTextColor(Palette.PALE_BLUE);
+        totalLabel.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
+        totalLabel.setTypeface(Typeface.MONOSPACE, Typeface.BOLD);
+        totalLine.addView(totalLabel, new LinearLayout.LayoutParams(
+            0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f));
+        TextView totalVal = new TextView(activity);
+        totalVal.setText(String.valueOf(data.optLong("total", 0)));
+        totalVal.setTextColor(Palette.GOLD_TEXT);
+        totalVal.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
+        totalVal.setTypeface(Typeface.MONOSPACE, Typeface.BOLD);
+        totalLine.addView(totalVal);
+        panel.addView(totalLine);
+    }
+
+    private void addHeader(LinearLayout panel, String text) {
+        TextView header = new TextView(activity);
+        header.setText(text);
+        header.setTextColor(Palette.GOLD_TEXT);
+        header.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        header.setTypeface(Typeface.MONOSPACE, Typeface.BOLD);
+        header.setLetterSpacing(0.2f);
+        header.setGravity(Gravity.CENTER);
+        header.setPadding(0, activity.dpToPx(4), 0, activity.dpToPx(8));
+        panel.addView(header);
+        panel.addView(ModalChrome.makeEmberSeparator(activity),
+                      ModalChrome.emberSeparatorParams(activity, 8, 8, 0, 12));
+    }
+
+    private void addLine(LinearLayout panel, String text, int color, int sp, int topDp) {
+        TextView tv = new TextView(activity);
+        tv.setText(text);
+        tv.setTextColor(color);
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, sp);
+        tv.setTypeface(Typeface.MONOSPACE);
+        tv.setGravity(Gravity.CENTER);
+        LinearLayout.LayoutParams p = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT);
+        p.setMargins(0, activity.dpToPx(Math.max(topDp, 4)), 0, 0);
+        panel.addView(tv, p);
+    }
+
+}

--- a/android/app/src/main/jni/android-stats.c
+++ b/android/app/src/main/jni/android-stats.c
@@ -70,38 +70,41 @@ void androidNotifyAllyDied(const char *monsterName) {
     (*env)->DeleteLocalRef(env, activity);
 }
 
-void androidNotifyPlayerDied(const char *killedBy, int depth, int turns) {
+void androidNotifyPlayerDied(const char *killedBy, int depth, int deepest, int turns) {
     JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
     jobject activity = (jobject)SDL_AndroidGetActivity();
     jclass cls = (*env)->GetObjectClass(env, activity);
     jmethodID mid = (*env)->GetMethodID(env, cls, "onPlayerDied",
-                                        "(Ljava/lang/String;II)V");
+                                        "(Ljava/lang/String;III)V");
     if (mid) {
         jstring jcause = (*env)->NewStringUTF(env, killedBy ? killedBy : "");
-        (*env)->CallVoidMethod(env, activity, mid, jcause, (jint)depth, (jint)turns);
+        (*env)->CallVoidMethod(env, activity, mid, jcause, (jint)depth,
+                               (jint)deepest, (jint)turns);
         (*env)->DeleteLocalRef(env, jcause);
     }
     (*env)->DeleteLocalRef(env, cls);
     (*env)->DeleteLocalRef(env, activity);
 }
 
-void androidNotifyPlayerWon(boolean superVictory, int depth, int turns) {
+void androidNotifyPlayerWon(boolean superVictory, int depth, int deepest, int turns) {
     JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
     jobject activity = (jobject)SDL_AndroidGetActivity();
     jclass cls = (*env)->GetObjectClass(env, activity);
-    jmethodID mid = (*env)->GetMethodID(env, cls, "onPlayerWon", "(ZII)V");
+    jmethodID mid = (*env)->GetMethodID(env, cls, "onPlayerWon", "(ZIII)V");
     if (mid) (*env)->CallVoidMethod(env, activity, mid,
-                                    (jboolean)superVictory, (jint)depth, (jint)turns);
+                                    (jboolean)superVictory, (jint)depth,
+                                    (jint)deepest, (jint)turns);
     (*env)->DeleteLocalRef(env, cls);
     (*env)->DeleteLocalRef(env, activity);
 }
 
-void androidNotifyPlayerQuit(int depth, int turns) {
+void androidNotifyPlayerQuit(int depth, int deepest, int turns) {
     JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
     jobject activity = (jobject)SDL_AndroidGetActivity();
     jclass cls = (*env)->GetObjectClass(env, activity);
-    jmethodID mid = (*env)->GetMethodID(env, cls, "onPlayerQuit", "(II)V");
-    if (mid) (*env)->CallVoidMethod(env, activity, mid, (jint)depth, (jint)turns);
+    jmethodID mid = (*env)->GetMethodID(env, cls, "onPlayerQuit", "(III)V");
+    if (mid) (*env)->CallVoidMethod(env, activity, mid, (jint)depth,
+                                    (jint)deepest, (jint)turns);
     (*env)->DeleteLocalRef(env, cls);
     (*env)->DeleteLocalRef(env, activity);
 }

--- a/android/app/src/main/jni/android-stats.h
+++ b/android/app/src/main/jni/android-stats.h
@@ -17,11 +17,11 @@ void androidNotifyGameStart(unsigned long long seed);
 void androidNotifyMonsterKilled(const char *monsterName);
 void androidNotifyAllyFreed(const char *monsterName);
 void androidNotifyAllyDied(const char *monsterName);
-void androidNotifyPlayerDied(const char *killedBy, int depth, int turns);
+void androidNotifyPlayerDied(const char *killedBy, int depth, int deepest, int turns);
 void androidShowDeathScreen(const char *description, int turns);
 extern volatile boolean deathScreenDismissed;
-void androidNotifyPlayerWon(boolean superVictory, int depth, int turns);
-void androidNotifyPlayerQuit(int depth, int turns);
+void androidNotifyPlayerWon(boolean superVictory, int depth, int deepest, int turns);
+void androidNotifyPlayerQuit(int depth, int deepest, int turns);
 void androidNotifyAmuletPickedUp(void);
 
 #endif

--- a/android/app/src/main/jni/android-touch.c
+++ b/android/app/src/main/jni/android-touch.c
@@ -94,6 +94,16 @@ void androidSetLoadingVisible(boolean visible) {
     (*env)->DeleteLocalRef(env, activity);
 }
 
+void androidSetLoadingProgress(int percent) {
+    JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
+    jobject activity = (jobject)SDL_AndroidGetActivity();
+    jclass cls = (*env)->GetObjectClass(env, activity);
+    jmethodID mid = (*env)->GetMethodID(env, cls, "setLoadingProgress", "(I)V");
+    if (mid) (*env)->CallVoidMethod(env, activity, mid, (jint)percent);
+    (*env)->DeleteLocalRef(env, cls);
+    (*env)->DeleteLocalRef(env, activity);
+}
+
 void androidSetRestoringVisible(boolean visible) {
     JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
     jobject activity = (jobject)SDL_AndroidGetActivity();
@@ -391,6 +401,38 @@ JNIEXPORT void JNICALL
 Java_org_broguece_game_BrogueActivity_nativeDeathScreenDismissed(
         JNIEnv *env, jobject thiz) {
     deathScreenDismissed = true;
+}
+
+/* ---- Victory sequence ---- */
+
+static volatile boolean victorySequenceDismissed = false;
+
+// Shows the native paged victory sequence and blocks until dismissed.
+void androidShowVictorySequence(const char *json) {
+    victorySequenceDismissed = false;
+
+    JNIEnv *env = (JNIEnv *)SDL_AndroidGetJNIEnv();
+    jobject activity = (jobject)SDL_AndroidGetActivity();
+    jclass cls = (*env)->GetObjectClass(env, activity);
+    jmethodID mid = (*env)->GetMethodID(env, cls, "showVictorySequence",
+        "(Ljava/lang/String;)V");
+    if (mid) {
+        jstring jstr = (*env)->NewStringUTF(env, json);
+        (*env)->CallVoidMethod(env, activity, mid, jstr);
+        (*env)->DeleteLocalRef(env, jstr);
+    }
+    (*env)->DeleteLocalRef(env, cls);
+    (*env)->DeleteLocalRef(env, activity);
+
+    while (!victorySequenceDismissed) {
+        SDL_Delay(30);
+    }
+}
+
+JNIEXPORT void JNICALL
+Java_org_broguece_game_BrogueActivity_nativeVictorySequenceDismissed(
+        JNIEnv *env, jobject thiz) {
+    victorySequenceDismissed = true;
 }
 
 void androidDeathFlamesReady(void) {

--- a/fastlane/metadata/android/en-US/changelogs/1150122.txt
+++ b/fastlane/metadata/android/en-US/changelogs/1150122.txt
@@ -1,0 +1,6 @@
+- Added Victory and Super Victory Endings
+- Starting or resuming a game now fades in instead of cutting
+- Loading a saved game shows a progress percentage
+- Inventory count now matches the pack limit, so stacked items each count
+- Deepest depth now records how far a run reached, including wins
+- Fixed a duplicate high score on winning; wins now appear in run history

--- a/src/brogue/Items.c
+++ b/src/brogue/Items.c
@@ -2819,7 +2819,7 @@ static boolean displayMagicCharForItem(item *theItem) {
 }
 
 // Strip brogue color escape sequences (COLOR_ESCAPE + 3 bytes) from a string.
-static void stripEscapes(char *dest, const char *src, int maxLen) {
+void stripEscapes(char *dest, const char *src, int maxLen) {
     int j = 0;
     for (int i = 0; src[i] && j < maxLen - 1;) {
         if (src[i] == COLOR_ESCAPE) {
@@ -2832,7 +2832,7 @@ static void stripEscapes(char *dest, const char *src, int maxLen) {
 }
 
 // Write a JSON-escaped version of src into dest. Returns chars written (excluding NUL).
-static int jsonEscape(char *dest, const char *src, int maxLen) {
+int jsonEscape(char *dest, const char *src, int maxLen) {
     int j = 0;
     for (int i = 0; src[i] && j < maxLen - 2; i++) {
         char c = src[i];
@@ -2902,9 +2902,10 @@ char displayInventory(unsigned short categoryMask,
     char promptEsc[COLS * 2];
     jsonEscape(promptEsc, androidInventoryPrompt, sizeof(promptEsc));
     pos += snprintf(json, sizeof(json),
-        "{\"mode\":\"%s\",\"prompt\":\"%s\",\"items\":[",
+        "{\"mode\":\"%s\",\"prompt\":\"%s\",\"packCount\":%d,\"items\":[",
         waitForAcknowledge ? "inventory" : "select",
-        promptEsc);
+        promptEsc,
+        numberOfItemsInPack());
 
     for (i = 0; i < itemNumber; i++) {
         theItem = itemList[i];

--- a/src/brogue/Recordings.c
+++ b/src/brogue/Recordings.c
@@ -27,6 +27,7 @@
 #include "GlobalsBase.h"
 #include "Globals.h"
 #include "platform.h"
+#include "tiles.h"
 
 #define RECORDING_HEADER_LENGTH     36  // bytes at the start of the recording file to store global data
 
@@ -1385,6 +1386,8 @@ void switchToPlaying() {
     refreshSideBar(-1, -1, false);
     updateMessageDisplay();
     displayLevel();
+    refreshScreen();
+    updateScreen();
     androidSetOverlayVisible(true);
 }
 
@@ -1431,6 +1434,7 @@ boolean loadSavedGame() {
             if (recordingLocation / progressBarInterval != previousRecordingLocation / progressBarInterval && !rogue.playbackOOS) {
                 rogue.playbackFastForward = false; // so that pauseBrogue looks for inputs
                 printProgressBar((COLS - 20) / 2, ROWS / 2, "[     Loading...   ]", recordingLocation, lengthOfPlaybackFile, &darkPurple, false);
+                androidSetLoadingProgress((int)((unsigned long long)recordingLocation * 100 / lengthOfPlaybackFile));
                 while (pauseBrogue(0, PAUSE_BEHAVIOR_DEFAULT)) { // pauseBrogue(0) is necessary to flush the display to the window in SDL, as well as look for inputs
                     rogue.creaturesWillFlashThisTurn = false; // prevent monster flashes from showing up on screen
                     nextBrogueEvent(&theEvent, true, false, true);

--- a/src/brogue/Rogue.h
+++ b/src/brogue/Rogue.h
@@ -3473,6 +3473,8 @@ extern "C" {
     void androidSaveGameAndExit(void);
     void androidAbandonGame(void);
     void androidDeleteSaveFile(void);
+    void stripEscapes(char *dest, const char *src, int maxLen);
+    int jsonEscape(char *dest, const char *src, int maxLen);
     boolean androidSaveFileExists(void);
     boolean androidSaveIsCompatible(void);
     void androidShowStartMenu(boolean hasSave, boolean saveCompatible);

--- a/src/brogue/RogueMain.c
+++ b/src/brogue/RogueMain.c
@@ -21,6 +21,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <math.h>
+#include <stdarg.h>
 #include "Rogue.h"
 #include "GlobalsBase.h"
 #include "Globals.h"
@@ -28,6 +30,7 @@
 #include "GlobalsRapidBrogue.h"
 #include "GlobalsBulletBrogue.h"
 #include "platform.h"
+#include "tiles.h"
 #include "android-stats.h"
 
 #include <time.h>
@@ -924,6 +927,10 @@ void startLevel(short oldLevelNumber, short stairDirection) {
     displayLevel();
     refreshSideBar(-1, -1, false);
     if (!rogue.playbackMode) {
+        // displayLevel only fills the buffers; paint them before telling the
+        // UI the game is up, or its transition fades in on the title frame.
+        refreshScreen();
+        updateScreen();
         androidSetOverlayVisible(true);
     }
 
@@ -1161,10 +1168,12 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     if (!rogue.playbackMode) {
         if (!rogue.quit) {
             notifyEvent(GAMEOVER_DEATH, theEntry.score, 0, theEntry.description, recordingFilename);
-            androidNotifyPlayerDied(killedBy, rogue.depthLevel, (int)rogue.playerTurnNumber);
+            androidNotifyPlayerDied(killedBy, rogue.depthLevel, rogue.deepestLevel,
+                                    (int)rogue.playerTurnNumber);
         } else {
             notifyEvent(GAMEOVER_QUIT, theEntry.score, 0, theEntry.description, recordingFilename);
-            androidNotifyPlayerQuit(rogue.depthLevel, (int)rogue.playerTurnNumber);
+            androidNotifyPlayerQuit(rogue.depthLevel, rogue.deepestLevel,
+                                    (int)rogue.playerTurnNumber);
         }
     } else {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
@@ -1183,18 +1192,30 @@ void gameOver(char *killedBy, boolean useCustomPhrasing) {
     rogue.gameExitStatusCode = EXIT_STATUS_SUCCESS;
 }
 
+// Appends to a JSON buffer, returning the new offset. snprintf reports the
+// length it would have written, so accumulating it raw can push the offset
+// past the buffer and wrap the remaining-size argument.
+static int jsonAppend(char *buf, int pos, int size, const char *format, ...) {
+    va_list args;
+    int written;
+
+    if (pos >= size - 1) return size - 1;
+    va_start(args, format);
+    written = vsnprintf(buf + pos, size - pos, format, args);
+    va_end(args);
+    return (written < 0 || pos + written >= size) ? size - 1 : pos + written;
+}
+
 void victory(boolean superVictory) {
-    char buf[COLS*3], victoryVerb[20];
+    char buf[COLS*3], esc[COLS*6], victoryVerb[20];
     item *theItem;
-    short i, j, gemCount = 0;
+    short j, gemCount = 0;
     unsigned long totalValue = 0;
     rogueHighScoresEntry theEntry;
-    boolean isPlayback;
-    
+
     char recordingFilename[BROGUE_FILENAME_MAX] = {0};
 
     rogue.gameInProgress = false;
-    enterModalMode();
     flushBufferToFile();
 
     if (rogue.playbackFastForward) {
@@ -1202,94 +1223,123 @@ void victory(boolean superVictory) {
         displayLevel();
     }
 
-    //
-    // First screen - Congratulations...
-    //
-    if (superVictory) {
-        message(    "Light streams through the portal, and you are teleported out of the dungeon.", 0);
-        screenDisplayBuffer dbuf = dungeonDisplayBuffer;
-        funkyFade(&dbuf, &superVictoryColor, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
-        displayMoreSign();
-        printString("Congratulations; you have transcended the Dungeons of Doom!                 ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
-        displayMoreSign();
-        clearDisplayBuffer(&dbuf);
-        deleteMessages();
-        strcpy(displayedMessage[0], "You retire in splendor, forever renowned for your remarkable triumph.     ");
-    } else {
-        message(    "You are bathed in sunlight as you throw open the heavy doors.", 0);
-        screenDisplayBuffer dbuf = dungeonDisplayBuffer;
-        funkyFade(&dbuf, &white, 0, 240, mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), false);
-        displayMoreSign();
-        printString("Congratulations; you have escaped from the Dungeons of Doom!     ", mapToWindowX(0), mapToWindowY(-1), &black, &white, 0);
-        displayMoreSign();
-        deleteMessages();
-        strcpy(displayedMessage[0], "You sell your treasures and live out your days in fame and glory.");
+    androidHideGameUI();
+
+    // Clear the message rows so no stale text floats over the flood.
+    deleteMessages();
+    updateMessageDisplay();
+
+    // Whiteout radiating from the exit door, drawn by the renderer as a
+    // screen-space overlay above both tile layers so it covers the sidebar
+    // and every other region. Not skippable.
+    if (!nonInteractivePlayback) {
+        setRenderMode(RENDER_VICTORY);
+
+        short **distanceMap = allocGrid();
+        fillGrid(distanceMap, 0);
+        calculateDistances(distanceMap, player.loc.x, player.loc.y, T_OBSTRUCTS_PASSABILITY, 0, true, true);
+
+        int doorC, doorR;
+        dungeonCellToFloodCell(mapToWindowX(player.loc.x), mapToWindowY(player.loc.y), &doorC, &doorR);
+
+        // Screen distance from the door per cell, shortened on reachable
+        // floor so the light rushes along corridors ahead of the walls.
+        int scrW, scrH;
+        getScreenPixelSize(&scrW, &scrH);
+        if (scrW <= 0 || scrH <= 0) { scrW = 16; scrH = 9; }
+        double cellW = (double)scrW / COLS, cellH = (double)scrH / ROWS;
+
+        static double distPx[COLS][ROWS];
+        double maxDist = 1;
+        for (int c = 0; c < COLS; c++) {
+            for (int r = 0; r < ROWS; r++) {
+                double dx = (c - doorC) * cellW, dy = (r - doorR) * cellH;
+                double d = sqrt(dx*dx + dy*dy);
+                if (d > maxDist) maxDist = d;
+
+                int gx, gy;
+                floodCellToDungeonCell(c, r, &gx, &gy);
+                int mx = windowToMapX(gx), my = windowToMapY(gy);
+                if (coordinatesAreInMap(mx, my)
+                    && distanceMap[mx][my] >= 0 && distanceMap[mx][my] < 30000) {
+                    d /= 1.0 + (100.0 - min(100, distanceMap[mx][my])) / 100.;
+                }
+                distPx[c][r] = d;
+            }
+        }
+        freeGrid(distanceMap);
+
+        const double falloff = maxDist * 0.18; // soft leading edge
+        const short steps = 480;
+        for (short n = 0; n <= steps; n++) {
+            double t = (double)n / steps;
+            double front = t * t * (maxDist + falloff); // ease-in
+            for (int c = 0; c < COLS; c++) {
+                for (int r = 0; r < ROWS; r++) {
+                    double w = (front - distPx[c][r]) / falloff * 100;
+                    victoryFloodWeight[r][c] = (short)(w < 0 ? 0 : (w > 100 ? 100 : w));
+                }
+            }
+            if (pauseAnimation(16, PAUSE_BEHAVIOR_DEFAULT)) {
+                rogueEvent theEvent;
+                nextKeyOrMouseEvent(&theEvent, false, false); // discard: not skippable
+            }
+        }
     }
 
-    screenDisplayBuffer dbuf;
-    clearDisplayBuffer(&dbuf);
-
-    //
-    // Second screen - Show inventory and item's value
-    //
-    printString(displayedMessage[0], mapToWindowX(0), mapToWindowY(-1), &white, &black, &dbuf);
-
-    plotCharToBuffer(G_GOLD, mapToWindow((pos){ 2, 1 }), &yellow, &black, &dbuf);
-    printString("Gold", mapToWindowX(4), mapToWindowY(1), &white, &black, &dbuf);
-    sprintf(buf, "%li", rogue.gold);
-    printString(buf, mapToWindowX(60), mapToWindowY(1), &itemMessageColor, &black, &dbuf);
+    // Identify and tally the pack, building the payload for the native
+    // victory sequence.
+    char json[8192];
+    int pos = 0;
+    pos = jsonAppend(json, pos, sizeof(json),
+        "{\"super\":%s,\"headline\":\"%s\",\"congrats\":\"%s\",\"epilogue\":\"%s\","
+        "\"stinger\":\"%s\",\"treasure\":[{\"name\":\"GOLD\",\"value\":%li}",
+        superVictory ? "true" : "false",
+        superVictory ? "Light streams through the portal, and you are teleported out of the dungeon."
+                     : "You are bathed in sunlight as you throw open the heavy doors.",
+        superVictory ? "Congratulations!\\nYou have transcended the Dungeons of Doom!"
+                     : "Congratulations!\\nYou have escaped from the Dungeons of Doom!",
+        superVictory ? "You retire in splendor, forever renowned for your remarkable triumph."
+                     : "You sell your treasures and live out your days in fame and glory.",
+        superVictory ? "As the amulet cools in your grasp,\\n"
+                       "the warden's breath will ever burn upon your neck..."
+                     : "Far below, the warden still creeps...",
+        rogue.gold);
     totalValue += rogue.gold;
 
-    for (i = 4, theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+    for (theItem = packItems->nextItem; theItem != NULL; theItem = theItem->nextItem) {
+        long value;
         if (theItem->category & GEM) {
             gemCount += theItem->quantity;
         }
         if (theItem->category == AMULET && superVictory) {
-            plotCharToBuffer(G_AMULET, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, &dbuf);
-            printString("The Birthright of Yendor", mapToWindowX(4), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
-            sprintf(buf, "%li", max(0, itemValue(theItem) * 2));
-            printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
-            totalValue += max(0, itemValue(theItem) * 2);
-            i++;
+            strcpy(buf, "THE BIRTHRIGHT OF YENDOR");
+            value = max(0, itemValue(theItem) * 2);
         } else {
             identify(theItem);
-            itemName(theItem, buf, true, true, &white);
+            itemName(theItem, buf, true, true, NULL);
             upperCase(buf);
-
-            plotCharToBuffer(theItem->displayChar, (windowpos){ mapToWindowX(2), min(ROWS-1, i + 1) }, &yellow, &black, &dbuf);
-            printString(buf, mapToWindowX(4), min(ROWS-1, i + 1), &white, &black, &dbuf);
-
-            if (itemValue(theItem) > 0) {
-                sprintf(buf, "%li", max(0, itemValue(theItem)));
-                printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &itemMessageColor, &black, &dbuf);
-            }
-
-            totalValue += max(0, itemValue(theItem));
-            i++;
+            value = max(0, itemValue(theItem));
         }
+        char clean[COLS*3];
+        stripEscapes(clean, buf, sizeof(clean));
+        jsonEscape(esc, clean, sizeof(esc));
+        pos = jsonAppend(json, pos, sizeof(json),
+            ",{\"name\":\"%s\",\"value\":%li}", esc, value);
+        totalValue += value;
     }
-    i++;
-    printString("TOTAL:", mapToWindowX(2), min(ROWS-1, i + 1), &lightBlue, &black, &dbuf);
-    sprintf(buf, "%li", totalValue);
-    printString(buf, mapToWindowX(60), min(ROWS-1, i + 1), &lightBlue, &black, &dbuf);
 
-    funkyFade(&dbuf, &white, 0, 120, COLS/2, ROWS/2, true);
-    displayMoreSign();
+    pos = jsonAppend(json, pos, sizeof(json),
+        "],\"total\":%lu,\"achievements\":[", totalValue);
 
-    //
-    // Third screen - List of achievements with recording save prompt
-    //
-    blackOutScreen();
-
-    i = 4;
-    printString("Achievements", mapToWindowX(2), i++, &lightBlue, &black, NULL);
-
-    i++;
-    for (j = 0; i < ROWS && j < gameConst->numberFeats; j++) {
+    boolean firstFeat = true;
+    for (j = 0; j < gameConst->numberFeats; j++) {
         if (rogue.featRecord[j]) {
             sprintf(buf, "%s: %s", featTable[j].name, featTable[j].description);
-            printString(buf, mapToWindowX(2), i, &advancementMessageColor, &black, NULL);
-            i++;
+            jsonEscape(esc, buf, sizeof(esc));
+            pos = jsonAppend(json, pos, sizeof(json),
+                "%s\"%s\"", firstFeat ? "" : ",", esc);
+            firstFeat = false;
         }
     }
 
@@ -1308,17 +1358,10 @@ void victory(boolean superVictory) {
         theEntry.score /= 10;
     }
 
+    pos = jsonAppend(json, pos, sizeof(json),
+        "],\"score\":%li,\"turns\":%li}", theEntry.score, rogue.playerTurnNumber);
+
     if (rogue.mode != GAME_MODE_WIZARD && !rogue.playbackMode) {
-        saveHighScore(theEntry);
-    }
-
-    isPlayback = rogue.playbackMode;
-    rogue.playbackMode = false;
-    rogue.playbackMode = isPlayback;
-
-    displayMoreSign();
-
-    if (!rogue.playbackMode) {
         saveHighScore(theEntry);
     }
 
@@ -1332,12 +1375,15 @@ void victory(boolean superVictory) {
         } else {
             notifyEvent(GAMEOVER_VICTORY, theEntry.score, 0, theEntry.description, recordingFilename);
         }
-        androidNotifyPlayerWon(superVictory, rogue.depthLevel, (int)rogue.playerTurnNumber);
+        // The ascent decrements depthLevel to 0 before calling in, so the
+        // deepest-depth stat has to come from deepestLevel.
+        androidNotifyPlayerWon(superVictory, rogue.depthLevel, rogue.deepestLevel,
+                               (int)rogue.playerTurnNumber);
     } else {
         notifyEvent(GAMEOVER_RECORDING, 0, 0, "recording ended", "none");
     }
 
-    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_NORMAL) {
+    if (!rogue.playbackMode && rogue.mode != GAME_MODE_EASY && rogue.mode != GAME_MODE_WIZARD) {
         saveRunHistory(victoryVerb, "-", (int) theEntry.score, gemCount);
     }
 
@@ -1345,7 +1391,15 @@ void victory(boolean superVictory) {
         androidDeleteSaveFile();
     }
 
-    exitModalMode();
+    // Blocks until the last page is tapped.
+    if (!nonInteractivePlayback) {
+        androidShowVictorySequence(json);
+        // Replace the lingering white flood frame so no white can show
+        // through during teardown and title entry.
+        setRenderMode(RENDER_LOADING);
+        updateScreen();
+    }
+
     rogue.gameHasEnded = true;
     rogue.gameExitStatusCode = EXIT_STATUS_SUCCESS;
 }

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -109,12 +109,18 @@ void updateTitleScreenTile(int row, int column, enum displayGlyph glyph,
 void androidSetOverlayVisible(boolean visible);
 void androidHideGameUI(void);
 void androidSetLoadingVisible(boolean visible);
+void androidSetLoadingProgress(int percent);
+void androidShowVictorySequence(const char *json);
+extern short victoryFloodWeight[ROWS][COLS];
+void floodCellToDungeonCell(int col, int row, int *outCol, int *outRow);
+void dungeonCellToFloodCell(int col, int row, int *outCol, int *outRow);
+void getScreenPixelSize(int *w, int *h);
 void androidSetRestoringVisible(boolean visible);
 void androidApplySettings(void);
 void deathFlameLoop(volatile boolean *dismissed);
 void androidDeathFlamesReady(void);
 
-enum RenderMode { RENDER_TITLE, RENDER_GAMEPLAY, RENDER_MODAL, RENDER_LOADING };
+enum RenderMode { RENDER_TITLE, RENDER_GAMEPLAY, RENDER_MODAL, RENDER_LOADING, RENDER_VICTORY };
 void setRenderMode(enum RenderMode mode);
 enum RenderMode getRenderMode(void);
 void enterModalMode(void);

--- a/src/platform/tiles.c
+++ b/src/platform/tiles.c
@@ -62,6 +62,48 @@ static int8_t tileShifts[TILE_ROWS][TILE_COLS][2][MAX_TILE_SIZE][3];
 static ScreenTile dungeonTiles[ROWS][COLS]; // dungeon layer (rendered at 2x zoom)
 static ScreenTile uiTiles[ROWS][COLS];     // UI layer (sidebar, messages, bottom bar, modals — rendered at 1x)
 
+// Victory flood: per-cell whiteness (0..100) on a grid stretched across the
+// whole screen. The engine fills it each step; updateScreen paints it.
+short victoryFloodWeight[ROWS][COLS];
+
+// Geometry of the last gameplay frame, so flood cells and dungeon cells can
+// be converted through the screen positions they share.
+static int lastMapOffsetX, lastMapOffsetY, lastMapZoomW, lastMapZoomH;
+static int lastScreenW, lastScreenH;
+
+void getScreenPixelSize(int *w, int *h) {
+    *w = lastScreenW;
+    *h = lastScreenH;
+}
+
+void floodCellToDungeonCell(int col, int row, int *outCol, int *outRow) {
+    if (lastMapZoomW <= 0 || lastMapZoomH <= 0) {
+        *outCol = col;
+        *outRow = row;
+        return;
+    }
+    float sx = (col + 0.5f) * lastScreenW / COLS;
+    float sy = (row + 0.5f) * lastScreenH / ROWS;
+    int gx = (int)((sx - lastMapOffsetX) * COLS / lastMapZoomW);
+    int gy = (int)((sy - lastMapOffsetY) * ROWS / lastMapZoomH);
+    *outCol = max(0, min(COLS - 1, gx));
+    *outRow = max(0, min(ROWS - 1, gy));
+}
+
+void dungeonCellToFloodCell(int col, int row, int *outCol, int *outRow) {
+    if (lastScreenW <= 0 || lastScreenH <= 0) {
+        *outCol = col;
+        *outRow = row;
+        return;
+    }
+    float sx = lastMapOffsetX + (col + 0.5f) * lastMapZoomW / COLS;
+    float sy = lastMapOffsetY + (row + 0.5f) * lastMapZoomH / ROWS;
+    int gx = (int)(sx * COLS / lastScreenW);
+    int gy = (int)(sy * ROWS / lastScreenH);
+    *outCol = max(0, min(COLS - 1, gx));
+    *outRow = max(0, min(ROWS - 1, gy));
+}
+
 boolean plotToUiLayer = false; // set by commitDraws/refreshScreen to route plotChar → updateTile
 
 static ScreenTile titleScreenTiles[ROWS][TITLE_COLS];
@@ -97,6 +139,8 @@ void setRenderMode(enum RenderMode mode) {
         clearOverlayRegion();
     else if (mode == RENDER_TITLE)
         memset(uiTiles, 0, sizeof(uiTiles));
+    else if (mode == RENDER_VICTORY)
+        memset(victoryFloodWeight, 0, sizeof(victoryFloodWeight));
 }
 
 enum RenderMode getRenderMode(void) { return renderMode; }
@@ -870,6 +914,15 @@ void updateScreen() {
     outputWidth = zoomW;
     outputHeight = zoomH;
 
+    if (inGame) {
+        lastMapOffsetX = offsetX;
+        lastMapOffsetY = offsetY;
+        lastMapZoomW = outputWidth;
+        lastMapZoomH = outputHeight;
+        lastScreenW = screenW;
+        lastScreenH = screenH;
+    }
+
     createTextures(renderer, outputWidth, outputHeight);
 
     // Pass 1: render the map/title layer
@@ -955,6 +1008,29 @@ void updateScreen() {
                 }
             }
         }
+    }
+
+    // Pass 3: victory flood — white blended over both layers at each cell's
+    // weight, which is equivalent to averaging the cell's colors toward white.
+    if (renderMode == RENDER_VICTORY) {
+        SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
+        for (int x = 0; x < COLS; x++) {
+            int rx = x * screenW / COLS;
+            int rw = (x + 1) * screenW / COLS - rx;
+            if (rw == 0) continue;
+            for (int y = 0; y < ROWS; y++) {
+                short wgt = victoryFloodWeight[y][x];
+                if (wgt <= 0) continue;
+                int ry = y * screenH / ROWS;
+                int rh = (y + 1) * screenH / ROWS - ry;
+                if (rh == 0) continue;
+                SDL_SetRenderDrawColor(renderer, 255, 255, 255,
+                                       (Uint8)min(255, wgt * 255 / 100));
+                SDL_Rect dest = {rx, ry, rw, rh};
+                SDL_RenderFillRect(renderer, &dest);
+            }
+        }
+        SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_NONE);
     }
 
     SDL_RenderPresent(renderer);


### PR DESCRIPTION
  - Added Victory and Super Victory Endings
  - Starting or resuming a game now fades in instead of cutting
  - Loading a saved game shows a progress percentage
  - Inventory count now matches the pack limit, so stacked items each count
  - Deepest depth now records how far a run reached, including wins
  - Fixed a duplicate high score on winning; wins now appear in run history
